### PR TITLE
[Issue #6] Implementing globs to load data

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,6 @@
 {
 	"compilerOptions": {
-		"target": "es5",
+		"target": "es6",
 		"module": "commonjs",
         "moduleResolution": "node",
         "noImplicitAny": true,


### PR DESCRIPTION
Hi Lindsay,

This is a nice plugin, currently I'm implementing your plugin in a project, and I'm trying to reach out use data into some components as partials, and here I'm implementing globs in order to load data and changing the target to ES6 on TS compiler in order to allow Object.assign

This is an example to load external data:

As previous implementation (works as well)
`data: 'src/data.json'`

As an Array
`data: [
    'src/data.json',
    'dataPartials/**/*.json'
]`

Or just partials
`data: 'dataPartials/**/*.json'`

I hope you can find this useful. Thanks

Regards,

César
